### PR TITLE
feat: sort job openings by creation date

### DIFF
--- a/db/config.ts
+++ b/db/config.ts
@@ -1,4 +1,4 @@
-import { defineDb, defineTable, column } from 'astro:db';
+import { defineDb, defineTable, column, NOW } from "astro:db";
 
 const Openings = defineTable({
   columns: {
@@ -12,7 +12,7 @@ const Openings = defineTable({
     companyname: column.text(),
     companyurl: column.text(),
     companycategory: column.text({ optional: true }),
-    created_at: column.date(),
+    created_at: column.date({ default: NOW }),
   },
   indexes: [
     { on: ["jobname", "companyname"], unique: true },

--- a/db/config.ts
+++ b/db/config.ts
@@ -12,6 +12,7 @@ const Openings = defineTable({
     companyname: column.text(),
     companyurl: column.text(),
     companycategory: column.text({ optional: true }),
+    created_at: column.date(),
   },
   indexes: [
     { on: ["jobname", "companyname"], unique: true },

--- a/db/seed.ts
+++ b/db/seed.ts
@@ -9,7 +9,8 @@ export default async function () {
       jobcategory: "MARKETING",
       companyname: "Sienna",
       companyurl: "https://sienna.network/jobs/",
-      companycategory: "DeFi"
+      companycategory: "DeFi",
+      created_at: new Date("1970-01-01"),
     },
     {
       wallet: "0x1234567890",
@@ -18,7 +19,8 @@ export default async function () {
       jobcategory: "SECURITY",
       companyname: "Espresso Systems",
       companyurl: "https://jobs.lever.co/Espresso",
-      companycategory: "DeFi"
+      companycategory: "DeFi",
+      created_at: new Date("1970-01-01"),
     },
     {
       wallet: "0x1234567890",
@@ -27,7 +29,8 @@ export default async function () {
       jobcategory: "ENGINEERING",
       companyname: "Espresso Systems",
       companyurl: "https://jobs.lever.co/Espresso",
-      companycategory: "DeFi"
+      companycategory: "DeFi",
+      created_at: new Date("1970-01-01"),
     },
     {
       wallet: "0x1234567890",
@@ -36,7 +39,8 @@ export default async function () {
       jobcategory: "ENGINEERING",
       companyname: "Silent Research Labs",
       companyurl: "https://www.silentresearchlabs.org/company/careers",
-      companycategory: "DeFi"
+      companycategory: "DeFi",
+      created_at: new Date("1970-01-01"),
     },
     {
       wallet: "0x1234567890",
@@ -45,7 +49,8 @@ export default async function () {
       jobcategory: "ENGINEERING",
       companyname: "Silent Research Labs",
       companyurl: "https://www.silentresearchlabs.org/company/careers",
-      companycategory: "DeFi"
+      companycategory: "DeFi",
+      created_at: new Date("1970-01-01"),
     },
     {
       wallet: "0x1234567890",
@@ -54,7 +59,8 @@ export default async function () {
       jobcategory: "PRODUCT",
       companyname: "Silent Research Labs",
       companyurl: "https://www.silentresearchlabs.org/company/careers",
-      companycategory: "DeFi"
-    }
-  ])
+      companycategory: "DeFi",
+      created_at: new Date("1970-01-01"),
+    },
+  ]);
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,8 +2,11 @@
 import Layout from "../layouts/Layout.astro";
 //import jobs from "@data/jobsdata.json";
 import JobItem from "../components/JobItem.astro";
-import { db, Openings } from "astro:db";
-const jobs = await db.select().from(Openings);
+import { db, Openings, desc } from "astro:db";
+const jobs = await db
+  .select()
+  .from(Openings)
+  .orderBy(desc(Openings.created_at));
 
 // Get all unique categories
 const categories = [


### PR DESCRIPTION
This PR implements the default sorting by creation date for job openings.

The DB schema has been updated to add a created_at column which will default to "NOW" when adding new entries.



~~@vorcigernix how are you fetching the actual job data? I noticed a few different json files, but none seem to be imported by the frontend.~~

closes #3 